### PR TITLE
Makefile and .travis.yml updated to test client-python in osx, linux and windows envs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: bash
 os:
   - linux
   - osx
+  - windows
 
 script:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y miniconda3; fi
+  # - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y anaconda3; fi
   - make repository-test-data


### PR DESCRIPTION
Makefile and .travis.yml files are updated and builds are running in all environments.

There is an issue in the windows build. All the test cases are not passing. 

https://travis-ci.org/github/hapi-server/client-python/jobs/722388452