### PR TITLE
fixed link to hapi_demo.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Basic Example
 Documentation
 -------------
 
-Basic usage examples for various HAPI servers are given in `hapi_demo.py <https://github.com/hapi-server/client-python-notebooks/blob/master/hapi_demo.py>`__
+Basic usage examples for various HAPI servers are given in `hapi_demo.py <https://github.com/hapi-server/client-python/blob/master/hapi_demo.py>`__
 
 All of the features are extensively demonstrated in the `hapi_demo.ipynb <https://github.com/hapi-server/client-python-notebooks/blob/master/hapi_demo.ipynb>`__ Jupyter Notebook.
 


### PR DESCRIPTION
changed link and now it seems to work; recommend that this request be merged into master and the iss28 branch be deleted.